### PR TITLE
feat: 支持插件多选、指令过滤和数组表达式

### DIFF
--- a/client/components/expr-editor.vue
+++ b/client/components/expr-editor.vue
@@ -62,7 +62,7 @@
                 row.value = parseValue(row.valueText);
                 emitChange();
               }
-            " placeholder="比较值" />
+            " :placeholder="getValuePlaceholder(row.operator)" />
           <div class="row-btns">
             <k-button @click="insertRowAfter(i, 'and')">且（AND）</k-button>
             <k-button v-if="i === rows.length - 1" @click="insertRowAfter(i, 'or')">或（OR）</k-button>
@@ -372,6 +372,17 @@ function parseValue(text: string): unknown {
   const n = Number(t);
   if (Number.isFinite(n)) return n;
   return text;
+}
+
+// 获取输入框占位符提示
+function getValuePlaceholder(operator: string): string {
+  if (operator === 'eq' || operator === 'ne') {
+    return '比较值（支持逗号分割多值，如：A,B,C）'
+  }
+  if (operator === 'includes') {
+    return '包含值（支持逗号分割多值）'
+  }
+  return '比较值'
 }
 </script>
 

--- a/client/components/plugin-selector.vue
+++ b/client/components/plugin-selector.vue
@@ -1,0 +1,399 @@
+<template>
+  <div class="plugin-selector">
+    <!-- 触发按钮 -->
+    <button type="button" class="trigger-btn" @click="showDialog = true">
+      <span class="label">{{ displayText }}</span>
+      <span class="arrow">▾</span>
+    </button>
+
+    <!-- 多选对话框 -->
+    <teleport to="body">
+      <div v-if="showDialog" class="dialog-overlay" @click="showDialog = false">
+        <div class="dialog-content" @click.stop>
+          <div class="dialog-header">
+            <h3>{{ dialogTitle }}</h3>
+            <button class="close-btn" @click="showDialog = false">✕</button>
+          </div>
+
+          <div class="dialog-body">
+            <!-- 搜索和全选 -->
+            <div class="toolbar">
+              <label class="checkbox-item select-all">
+                <input
+                  type="checkbox"
+                  :checked="isAllSelected"
+                  @change="toggleSelectAll"
+                />
+                <span>全选</span>
+              </label>
+              <input
+                v-model="searchText"
+                class="search-input"
+                :placeholder="searchPlaceholder"
+              />
+            </div>
+
+            <!-- 插件/指令列表 -->
+            <div class="plugin-list">
+              <label
+                v-for="plugin in filteredPlugins"
+                :key="plugin.key"
+                class="checkbox-item"
+              >
+                <input
+                  type="checkbox"
+                  :value="plugin.key"
+                  :checked="localSelected.includes(plugin.key)"
+                  @change="togglePlugin(plugin.key)"
+                />
+                <span>{{ plugin.label }}</span>
+              </label>
+              <div v-if="filteredPlugins.length === 0" class="empty-state">
+                {{ emptyText }}
+              </div>
+            </div>
+          </div>
+
+          <div class="dialog-footer">
+            <button class="btn btn-cancel" @click="cancel">取消</button>
+            <button class="btn btn-confirm" @click="confirm">确定</button>
+          </div>
+        </div>
+      </div>
+    </teleport>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, watch } from 'vue'
+
+interface PluginOption {
+  key: string
+  name: string
+  ident: string
+  label: string
+}
+
+const props = defineProps<{
+  modelValue: string[]
+  options: PluginOption[]
+  mode?: 'plugin' | 'command' // 区分插件或指令模式
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string[]]
+}>()
+
+const showDialog = ref(false)
+const searchText = ref('')
+const localSelected = ref<string[]>([...props.modelValue])
+
+// 是否为指令模式
+const isCommandMode = computed(() => props.mode === 'command')
+
+// 对话框标题
+const dialogTitle = computed(() =>
+  isCommandMode.value ? '选择指令' : '选择插件实例'
+)
+
+// 搜索框占位符
+const searchPlaceholder = computed(() =>
+  isCommandMode.value ? '搜索指令...' : '搜索插件...'
+)
+
+// 空状态文本
+const emptyText = computed(() =>
+  isCommandMode.value ? '没有找到匹配的指令' : '没有找到匹配的插件'
+)
+
+// 显示文本
+const displayText = computed(() => {
+  const itemType = isCommandMode.value ? '指令' : '插件'
+  const selectPrompt = isCommandMode.value ? '请选择指令' : '请选择插件实例'
+
+  if (localSelected.value.length === 0) return selectPrompt
+  if (localSelected.value.length === 1) {
+    const plugin = props.options.find((p) => p.key === localSelected.value[0])
+    return plugin?.label || `已选择 1 个${itemType}`
+  }
+  return `已选择 ${localSelected.value.length} 个${itemType}`
+})
+
+// 过滤后的插件列表
+const filteredPlugins = computed(() => {
+  if (!searchText.value) return props.options
+  const search = searchText.value.toLowerCase()
+  return props.options.filter((p) =>
+    p.label.toLowerCase().includes(search)
+  )
+})
+
+// 是否全选
+const isAllSelected = computed(() => {
+  return (
+    filteredPlugins.value.length > 0 &&
+    filteredPlugins.value.every((p) => localSelected.value.includes(p.key))
+  )
+})
+
+// 切换单个插件
+function togglePlugin(key: string) {
+  const index = localSelected.value.indexOf(key)
+  if (index > -1) {
+    localSelected.value.splice(index, 1)
+  } else {
+    localSelected.value.push(key)
+  }
+}
+
+// 切换全选
+function toggleSelectAll(e: Event) {
+  const checked = (e.target as HTMLInputElement).checked
+  if (checked) {
+    // 全选当前过滤的插件
+    for (const plugin of filteredPlugins.value) {
+      if (!localSelected.value.includes(plugin.key)) {
+        localSelected.value.push(plugin.key)
+      }
+    }
+  } else {
+    // 取消选择当前过滤的插件
+    localSelected.value = localSelected.value.filter(
+      (key) => !filteredPlugins.value.some((p) => p.key === key)
+    )
+  }
+}
+
+// 确定
+function confirm() {
+  emit('update:modelValue', [...localSelected.value])
+  showDialog.value = false
+}
+
+// 取消
+function cancel() {
+  localSelected.value = [...props.modelValue]
+  showDialog.value = false
+}
+
+// 监听外部变化
+watch(
+  () => props.modelValue,
+  (val) => {
+    localSelected.value = [...val]
+  }
+)
+
+// 打开对话框时重置搜索
+watch(showDialog, (val) => {
+  if (val) {
+    searchText.value = ''
+  }
+})
+</script>
+
+<style scoped>
+.plugin-selector {
+  position: relative;
+  min-width: 140px;
+}
+
+.trigger-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--k-text-normal, inherit);
+  background: var(--k-input-bg, transparent);
+  border: 1px solid var(--k-card-border, rgba(127, 127, 127, 0.35));
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.trigger-btn:hover {
+  border-color: var(--k-color-primary, #4f7cff);
+}
+
+.label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  text-align: left;
+}
+
+.arrow {
+  flex-shrink: 0;
+}
+
+/* 对话框 */
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.dialog-content {
+  background: var(--k-card-bg, #1e1e1e);
+  border: 1px solid var(--k-card-border, rgba(127, 127, 127, 0.35));
+  border-radius: 12px;
+  width: 90%;
+  max-width: 500px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--k-card-border, rgba(127, 127, 127, 0.2));
+}
+
+.dialog-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--k-text-normal, inherit);
+}
+
+.close-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--k-text-secondary, #888);
+  cursor: pointer;
+  font-size: 18px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.close-btn:hover {
+  color: var(--k-text-normal, inherit);
+  background: color-mix(in srgb, var(--k-card-border, #888) 20%, transparent);
+}
+
+.dialog-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 16px 20px;
+  overflow: hidden;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.select-all {
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+.search-input {
+  flex: 1;
+  min-width: 0;
+  color: var(--k-text-normal, inherit);
+  background: var(--k-input-bg, transparent);
+  border: 1px solid var(--k-card-border, rgba(127, 127, 127, 0.35));
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 14px;
+}
+
+.plugin-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+  user-select: none;
+}
+
+.checkbox-item:hover {
+  background: color-mix(in srgb, var(--k-card-border, #888) 15%, transparent);
+}
+
+.checkbox-item input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.checkbox-item span {
+  color: var(--k-text-normal, inherit);
+  font-size: 14px;
+}
+
+.empty-state {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--k-text-secondary, #888);
+}
+
+.dialog-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--k-card-border, rgba(127, 127, 127, 0.2));
+}
+
+.btn {
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  transition: opacity 0.15s;
+}
+
+.btn:hover {
+  opacity: 0.85;
+}
+
+.btn-cancel {
+  background: transparent;
+  color: var(--k-text-normal, inherit);
+  border: 1px solid var(--k-card-border, rgba(127, 127, 127, 0.35));
+}
+
+.btn-confirm {
+  background: var(--k-color-primary, #4f7cff);
+  color: #fff;
+}
+</style>


### PR DESCRIPTION
### 新增功能

#### 1. 插件多选功能
- 新增 `plugin-selector.vue` 组件，支持多选插件实例
- 提供搜索过滤和全选功能
- 显示已选择的插件/指令数量
- 支持插件和指令两种模式，UI 文本自动适配

#### 2. 指令过滤功能
- 扩展目标类型，新增"指令"选项（`global` | `plugin` | `command`）
- 实现指令级别的拦截逻辑，在 `ctx.before('command/execute')` 中处理
- 新增 `filter-pro/commands` API 端点获取指令列表
- 支持多选指令进行拦截或放行

#### 3. 数组表达式支持
- 实现 `parseMultiValue()` 函数，支持全角、半角逗号分割多值
- 更新 `evaluateCompare()` 函数：
  - `eq` 操作符：左值等于右值数组中的任意一个（如：`群组ID 等于 A,B,C,D`）
  - `ne` 操作符：左值不等于右值数组中的所有值
  - `includes` 操作符：左值包含右值数组中的任意一个
- 在表达式编辑器中添加输入提示，告知用户可以使用逗号分割多值

### 改进

#### UI/UX 优化
- 目标类型切换时自动清空已选值
- 规则列表显示优化，支持显示多选数量（如：`插件 (3)`、`指令 (5)`）
- 对话框标题和搜索框占位符根据模式自动调整

#### 类型安全
- 更新 `RuleTarget` 接口，支持 `value?: string | string[]`
- 修复所有类型错误，通过 TypeScript 编译检查
- 正确处理插件和指令的数组值匹配逻辑

### 技术细节

#### 后端变更
- `src/index.ts`:
  - 扩展 `TargetType` 类型
  - 更新 `normalizeRule()` 函数支持数组值
  - 更新 `matchTarget()` 函数支持插件和指令的数组匹配
  - 实现 `parseMultiValue()` 和更新 `evaluateCompare()` 支持数组表达式
  - 新增指令级拦截逻辑
  - 新增 `filter-pro/commands` API 端点

#### 前端变更
- `client/components/plugin-selector.vue`: 新增多选组件
- `client/page.vue`: 
  - 集成多选组件
  - 添加指令目标类型
  - 实现目标类型切换时清空已选值
  - 更新保存逻辑支持数组值
- `client/components/expr-editor.vue`: 添加输入提示

### 测试
- ✅ TypeScript 编译检查通过
- ✅ 支持 HMR 热重载

### 兼容性
- 向后兼容：旧的单选插件配置会自动转换为数组格式
- 全局目标类型保持不变

---

<img width="1826" height="1045" alt="PixPin_2026-02-24_15-50-18" src="https://github.com/user-attachments/assets/cd77852f-6b5a-466f-898b-a97cb4f6d047" />


<img width="2560" height="1218" alt="PixPin_2026-02-24_15-50-23" src="https://github.com/user-attachments/assets/28266300-e827-4e9c-b12d-992544a760a6" />


<img width="2560" height="1218" alt="PixPin_2026-02-24_15-50-29" src="https://github.com/user-attachments/assets/4e567fbb-efce-4e0e-8e50-87e0d075bd7c" />
