### PR TITLE
fix(filter-pro): delay debug check until stage evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-filter-pro",
   "description": "A powerful filter plugin for Koishi",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",

--- a/src/apply.ts
+++ b/src/apply.ts
@@ -30,10 +30,9 @@ export function apply(ctx: Context, config: Config = {}) {
   const state: RuleState = { rules: [] }
   const persist = createPersister(dataFile)
   const logger = ctx.logger('filter-pro')
-  const debug = !!config.debug
 
   const trace = (stage: string, payload: Record<string, unknown>) => {
-    if (!debug) return
+    if (!config.debug) return
     if (stage !== 'native-filter:evaluate') return
     if (!payload?.matched) return
     logger.info('[trace:%s] %s', stage, JSON.stringify(payload))


### PR DESCRIPTION
修复 debug 模式关闭后仍输出日志的问题。

问题原因：在 `src/apply.ts:33` 中，`debug` 变量在插件初始化时被固化为常量，导致配置更新后无法生效。

解决方案：移除了固化的 `debug` 常量，让 `trace` 函数直接动态读取 `config.debug`，这样当用户在配置界面关闭 debug 时，Koishi 的热重载会更新 config 对象，日志输出会立即停止，无需重启进程。

---

https://github.com/Hoshino-Yumetsuki/koishi-plugin-filter-pro/issues/8